### PR TITLE
feat: Add --no-color flag and automatic color disabling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,8 +15,11 @@ const version = pkg.version;
 //   2. NO_COLOR environment variable (disables colors)
 //   3. FORCE_COLOR environment variable (forces colors even in non-TTY)
 //   4. TTY detection (auto-disable for piped/redirected output)
+// Note: This function runs at module load, before CLI parsing.
+// The --no-color flag is handled separately in preAction hook and can
+// override these settings because it runs after this initial check.
 const shouldDisableColors = () => {
-  // 1. NO_COLOR environment variable always wins (https://no-color.org/)
+  // NO_COLOR environment variable (https://no-color.org/)
   if (process.env.NO_COLOR !== undefined) {
     return true;
   }

--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,7 @@ const version = pkg.version;
 // Check if colors should be disabled based on environment
 // Full color control precedence (highest to lowest priority):
 //   1. --no-color CLI flag (handled later in preAction hook; overrides all below)
-//   2. NO_COLOR environment variable (disables colors)
+//   2. NO_COLOR environment variable (disables colors, takes precedence over FORCE_COLOR)
 //   3. FORCE_COLOR environment variable (forces colors even in non-TTY)
 //   4. TTY detection (auto-disable for piped/redirected output)
 // Note: This function runs at module load, before CLI parsing.
@@ -23,11 +23,11 @@ const shouldDisableColors = () => {
   if (process.env.NO_COLOR !== undefined) {
     return true;
   }
-  // 2. FORCE_COLOR forces colors even in non-TTY environments
+  // FORCE_COLOR forces colors even in non-TTY environments
   if (process.env.FORCE_COLOR !== undefined && process.env.FORCE_COLOR !== '0' && process.env.FORCE_COLOR !== '') {
     return false;
   }
-  // 3. Check for non-TTY output (piped or redirected)
+  // Non-TTY output (piped or redirected)
   if (!process.stdout.isTTY) {
     return true;
   }

--- a/cli.js
+++ b/cli.js
@@ -9,20 +9,26 @@ import chalk from 'chalk';
 const { default: pkg } = await import('./package.json', { with: { type: "json" } });
 const version = pkg.version;
 
-// Check if colors should be disabled
+// Check if colors should be disabled based on environment
+// Precedence: NO_COLOR > FORCE_COLOR > TTY detection
 const shouldDisableColors = () => {
-  // Check for NO_COLOR environment variable (https://no-color.org/)
+  // 1. NO_COLOR environment variable always wins (https://no-color.org/)
   if (process.env.NO_COLOR !== undefined) {
     return true;
   }
-  // Check for non-TTY output (piped or redirected)
+  // 2. FORCE_COLOR forces colors even in non-TTY environments
+  if (process.env.FORCE_COLOR !== undefined && process.env.FORCE_COLOR !== '0' && process.env.FORCE_COLOR !== '') {
+    return false;
+  }
+  // 3. Check for non-TTY output (piped or redirected)
   if (!process.stdout.isTTY) {
     return true;
   }
   return false;
 };
 
-// Disable chalk colors if needed (before parsing args for --no-color)
+// Disable chalk colors at module load for env vars and TTY detection
+// (--no-color flag is handled separately in preAction hook after CLI parsing)
 if (shouldDisableColors()) {
   chalk.level = 0;
 }

--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,11 @@ const { default: pkg } = await import('./package.json', { with: { type: "json" }
 const version = pkg.version;
 
 // Check if colors should be disabled based on environment
-// Precedence: NO_COLOR > FORCE_COLOR > TTY detection
+// Full color control precedence (highest to lowest priority):
+//   1. --no-color CLI flag (handled in preAction hook after parsing)
+//   2. NO_COLOR environment variable (disables colors)
+//   3. FORCE_COLOR environment variable (forces colors even in non-TTY)
+//   4. TTY detection (auto-disable for piped/redirected output)
 const shouldDisableColors = () => {
   // 1. NO_COLOR environment variable always wins (https://no-color.org/)
   if (process.env.NO_COLOR !== undefined) {

--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ const version = pkg.version;
 
 // Check if colors should be disabled based on environment
 // Full color control precedence (highest to lowest priority):
-//   1. --no-color CLI flag (handled in preAction hook after parsing)
+//   1. --no-color CLI flag (handled later in preAction hook; overrides all below)
 //   2. NO_COLOR environment variable (disables colors)
 //   3. FORCE_COLOR environment variable (forces colors even in non-TTY)
 //   4. TTY detection (auto-disable for piped/redirected output)

--- a/e2e.test.js
+++ b/e2e.test.js
@@ -320,6 +320,45 @@ describe('CLI Output Format', () => {
 });
 
 // =============================================================================
+// Color Control Tests
+// =============================================================================
+describe('Color Control', () => {
+  const fixturePath = join(__dirname, 'test', 'fixtures', 'minimal.md');
+
+  it('should disable colors with --no-color flag', () => {
+    const output = execSync(`node --no-warnings cli.js --no-color analyze "${fixturePath}"`, {
+      encoding: 'utf-8',
+      env: { ...process.env, FORCE_COLOR: '1' } // Force color would normally enable
+    });
+    // Check that no ANSI escape codes are present
+    assert.ok(!/\x1b\[/.test(output), 'Output should not contain ANSI escape codes');
+    // But content should still be readable
+    assert.ok(output.includes('Total Score'), 'Output should still contain score');
+  });
+
+  it('should disable colors with NO_COLOR environment variable', () => {
+    const output = execSync(`node --no-warnings cli.js analyze "${fixturePath}"`, {
+      encoding: 'utf-8',
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: undefined }
+    });
+    // Check that no ANSI escape codes are present
+    assert.ok(!/\x1b\[/.test(output), 'Output should not contain ANSI escape codes');
+    // But content should still be readable
+    assert.ok(output.includes('Total Score'), 'Output should still contain score');
+  });
+
+  it('should produce readable output without colors', () => {
+    const output = execSync(`node --no-warnings cli.js --no-color analyze "${fixturePath}"`, {
+      encoding: 'utf-8'
+    });
+    // Verify key content is present and readable
+    assert.ok(output.includes('Analyzing README file'), 'Should show analyzing message');
+    assert.ok(output.includes('Total Score:'), 'Should show score');
+    assert.ok(output.includes('Missing Sections') || output.includes('All sections'), 'Should show section status');
+  });
+});
+
+// =============================================================================
 // Error Handling Tests
 // =============================================================================
 describe('Error Handling', () => {

--- a/e2e.test.js
+++ b/e2e.test.js
@@ -369,6 +369,19 @@ describe('Color Control', () => {
     // But content should still be readable
     assert.ok(output.includes('Total Score'), 'Output should still contain score');
   });
+
+  it('should enable colors when FORCE_COLOR is set (simulates TTY)', () => {
+    // Properly exclude NO_COLOR from env to ensure colors are enabled
+    const { NO_COLOR, ...envWithoutNoColor } = process.env;
+    const output = execSync(`node --no-warnings cli.js analyze "${fixturePath}"`, {
+      encoding: 'utf-8',
+      env: { ...envWithoutNoColor, FORCE_COLOR: '1' }
+    });
+    // Check that ANSI escape codes ARE present when FORCE_COLOR is set
+    assert.ok(/\x1b\[/.test(output), 'Output should contain ANSI escape codes when FORCE_COLOR=1');
+    // And content should still be readable
+    assert.ok(output.includes('Total Score'), 'Output should still contain score');
+  });
 });
 
 // =============================================================================

--- a/e2e.test.js
+++ b/e2e.test.js
@@ -337,7 +337,7 @@ describe('Color Control', () => {
   });
 
   it('should disable colors with NO_COLOR environment variable', () => {
-    // Properly exclude FORCE_COLOR from env to avoid setting it to "undefined" string
+    // Properly excludes FORCE_COLOR from env to avoid setting it to "undefined" string
     const { FORCE_COLOR, ...envWithoutForceColor } = process.env;
     const output = execSync(`node --no-warnings cli.js analyze "${fixturePath}"`, {
       encoding: 'utf-8',
@@ -371,7 +371,7 @@ describe('Color Control', () => {
   });
 
   it('should enable colors when FORCE_COLOR is set (simulates TTY)', () => {
-    // Properly exclude NO_COLOR from env to ensure colors are enabled
+    // Properly excludes NO_COLOR from env to ensure colors are enabled
     const { NO_COLOR, ...envWithoutNoColor } = process.env;
     const output = execSync(`node --no-warnings cli.js analyze "${fixturePath}"`, {
       encoding: 'utf-8',


### PR DESCRIPTION
## Summary

- Add `--no-color` CLI flag to disable colored output
- Respect `NO_COLOR` environment variable (per [no-color.org](https://no-color.org/) standard)
- Automatically disable colors when output is piped or redirected (non-TTY)

This allows clean output for CI/CD pipelines and logging systems.

Closes #15

## Test plan

- [x] Test `--no-color` flag disables ANSI escape codes
- [x] Test `NO_COLOR=1` environment variable disables colors
- [x] Test non-TTY detection works (piped output)
- [x] Verify output is still readable without colors
- [x] All 177 existing tests pass

### Manual verification

```bash
# Test --no-color flag
readme-stats --no-color analyze README.md

# Test NO_COLOR environment variable
NO_COLOR=1 readme-stats analyze README.md

# Test piped output (automatic detection)
readme-stats analyze README.md | cat
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)